### PR TITLE
Fix extraction of encoding from meta element

### DIFF
--- a/emeraldtree/html.py
+++ b/emeraldtree/html.py
@@ -96,12 +96,9 @@ class HTMLParser(HTMLParserBase):
                 elif k == "content":
                     content = v
             if http_equiv == "content-type" and content:
-                # use mimetools to parse the http header
-                import mimetools, StringIO
-                header = mimetools.Message(
-                    StringIO.StringIO("%s: %s\n\n" % (http_equiv, content))
-                    )
-                encoding = header.getparam("charset")
+                import cgi
+                _, params = cgi.parse_header(content)
+                encoding = params.get('charset')
                 if encoding:
                     self.encoding = encoding
         if tag.name in self.AUTOCLOSE:

--- a/emeraldtree/tests/test_html.py
+++ b/emeraldtree/tests/test_html.py
@@ -54,3 +54,10 @@ def test_write():
     assert '<br /><p></p>' in p
     assert '<br /><p />' in x
 
+def test_read_meta():
+    parser = html.HTMLParser()
+    assert parser.encoding == 'iso-8859-1'
+
+    parser.feed('<meta http-equiv="content-type" content="text/html; charset=UTF-8">"')
+    assert parser.encoding == 'UTF-8'
+    parser.close()


### PR DESCRIPTION
When a meta element was parsed, with a http-equiv of `content-type` it
was using `mimetools` to do so.  This was deprecated since Python 2.3,
and as is pointed out by https://github.com/moinwiki/moin/issues/1089
does not work in Python 3.

This change uses the cgi module, and parse_header in particular to parse
the value correctly.

Fixes https://github.com/moinwiki/moin/issues/1089