### PR TITLE
Fix tostring() by joining with bytes instead of str

### DIFF
--- a/src/emeraldtree/tree.py
+++ b/src/emeraldtree/tree.py
@@ -667,7 +667,7 @@ class ElementTree:
 
 def tostring(element, encoding=None, method=None):
     data = tostringlist(element, encoding, method)
-    return "".join(data)
+    return b"".join(data)
 
 ##
 # Generates a string representation of an XML element, including all


### PR DESCRIPTION
Apparently a leftover from Python 2 to 3 migration, `tostring()` joined the result of `tostringlist()` with an empty `str` instead of an empty `bytes`. This PR fixes the issue in a way that mirrors the standard library's `xml.etree`.